### PR TITLE
Fixed wrong indentation of separators in lua/galaxyline-config/init.lua

### DIFF
--- a/lua/galaxyline-config/init.lua
+++ b/lua/galaxyline-config/init.lua
@@ -77,7 +77,7 @@ end
 
 local colors = get_colors()
 
-local separators = {bLeft = '  ', bRight = ' ', uLeft = ' ', uTop = ' '}
+local separators = {bLeft = '  ', bRight = '', uLeft = ' ', uTop = ' '}
 
 -- Functions
 local buffer_not_empty = function()


### PR DESCRIPTION
**Before:**

![before](https://user-images.githubusercontent.com/28064429/138552831-89084a82-2696-40e4-b6a8-12c03f95b0dc.png)



**After:**

![after](https://user-images.githubusercontent.com/28064429/138552841-ff9e1154-18f1-4244-b088-1ab0ff9673e6.png)
