### PR TITLE
feat: change treesitter ensure installed to lua

### DIFF
--- a/lua/vapour/init.lua
+++ b/lua/vapour/init.lua
@@ -71,7 +71,7 @@ Vapour = {
     },
     treesitter = {
       enabled = true,
-      ensure_installed = "all",
+      ensure_installed = "lua",
       ignore_install = {},
       indent = {enable = false},
       highlight = {enable = true},


### PR DESCRIPTION
I believe that doing this is aligned with VapourNvim's second
goal which is "minimal". Setting it to "all" is not a good option
espescially in a low end device

so, user can just do :TSInstall langa langb langc langd etc
or through Vapour.plugins.treesitter.ensure_installed